### PR TITLE
[FEAT] Add global config.yml utilizing artifactory cache

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,49 @@
+# Global config.yml file to be used by all DTAG projects.
+#
+# This config uses a central ORT Artifactory Cache maintained by OpenSource@DTIT.
+# The credentials are set globally in the entire github.com/telekom organization.
+# If everyone contributes to the cache, scans will become much faster.
+#
+# If this config doesn't meet your needs, feel free to patch values in your
+# workflows using yq or replacing the file entirely after cloning the repo.
+
+ort:
+  # Allows defining package configs/curations in the repository's .ort.yml file
+  enableRepositoryPackageConfigurations: true
+  enableRepositoryPackageCurations: true
+
+  # These could be used in the future to not treat warnings as severe issues
+  #severeIssueThreshold: ERROR
+  #severeRuleViolationThreshold: ERROR
+
+  # Force overwriting of existing reports
+  forceOverwrite: true
+
+  analyzer:
+    # Allow version ranges in dependency specifications
+    allowDynamicVersions: true
+    skipExcluded: true
+  downloader:
+    skipExcluded: true
+    # Allow downloads using symbolic names that point to moving revisions, like Git branches
+    allowMovingRevisions: true
+  scanner:
+    storages:
+      # Read/write results to actions cache
+      local:
+        backend:
+          localFileStorage:
+            directory: /home/ort/.ort/scanner/results
+            compression: false
+      # Read/write results to OpenSource@DTIT ORT cache on artifactory
+      artifactory:
+        backend:
+          httpFileStorage:
+            url: "https://artifactory.devops.telekom.de/artifactory/open-source-dtit-ort-generic/ort/scan-results"
+            headers:
+              Authorization: "Bearer ${ORT_ARTIFACTORY_TOKEN}"
+    storageReaders: ["local", "artifactory"]
+    storageWriters: ["artifactory", "local"]
+    skipExcluded: true
+  advisor:
+    skipExcluded: true


### PR DESCRIPTION
_Note: I have spoken about this before with @daniel-eder and got a positive response. Here is a PR implementing the idea 🙂_ 

This PR introduces a common config.yml that can be used by all open source projects in the Telekom organization.

It includes some sane defaults and by default uses a common cache held in Artifactory that we would like to maintain in the OpenSource@DTIT community.

I am hoping that a common cache across all projects will speed up scans for all projects in the org immensely. In own tests (using a [Golang Kubebuilder Operator](https://github.com/telekom/gateway-rotator)) I could see a reduction in runtime between uncached and cached runs from ~4h to around 5min (if no dependencies have changed). This would remove the need for a centrally managed ort-server, which would require infrastructure and be more painful to maintain than a simple cache.

The idea is to create a shared secret `ORT_ARTIFACTORY_TOKEN` on org level that has a token with read/write access to the cache. Projects could simply define a GitHub action like this to instantly use it without any setup required:

```yaml
jobs:
  ort:
    name: ORT scan
    runs-on: ubuntu-latest
    #needs:
    #  - check-changes
    #if: ${{ needs.check-changes.outputs.deps == 'true' }} # Only run if deps have changed
    steps:
      - name: Use HTTPS for Git cloning
        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
      - name: Checkout project
        uses: actions/checkout@v3
      - name: Prepare ORT config
        run: |
          # Move into default config dir
          export ORT_CONFIG_DIR=$HOME/.ort/config
          mkdir -p ${ORT_CONFIG_DIR}
          cd ${ORT_CONFIG_DIR}
          # Checkout default config repo
          git init -q
          git remote add origin https://github.com/telekom/ort-config.git
          git fetch -q --depth 1 origin main
          git checkout -q FETCH_HEAD
          # If required, a project could even patch certain files here using yq
      - name: Run GitHub Action for ORT
        uses: oss-review-toolkit/ort-ci-github-action@v1
        with:
          fail-on: violations
          docker-cli-args: >-
            -e ORT_ARTIFACTORY_TOKEN=${{ secrets.ORT_ARTIFACTORY_TOKEN }}
          run: >
            cache-dependencies,
            cache-scan-results,
            labels,
            analyzer,
            scanner,
            advisor,
            evaluator,
            reporter,
            upload-results
```

We could provide documentation for this in the [OpenSource@DTIT documentation](https://open-source-dtit.pages.devops.telekom.de/documentation/) which will be integrated into the central [DX documentation](https://mdx.pages.devops.telekom.de/docs/) soon.

Open To Do's before merge:
- [ ] Create org wide secret


Looking forward to your feedback!